### PR TITLE
Fix misplaced types in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,9 +17,9 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "types": ["jest"]
   },
   "exclude": ["node_modules"],
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "pages/index.tsx"],
-  "types": ["jest"]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "pages/index.tsx"]
 }


### PR DESCRIPTION
## Summary
- place `types` under `compilerOptions` in tsconfig

## Testing
- `npm run lint`
- `npm run format-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68444734a05c832eb7f755b5a9660a82