### PR TITLE
Simplify hero section and remove editorial components

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -75,28 +75,6 @@ p {
   margin-inline: auto;
 }
 
-/* Editorial section header: (index) — LABEL ———————— */
-.eyebrow {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  margin-bottom: clamp(2.5rem, 5vw, 4.5rem);
-  font-size: 0.6875rem;
-  letter-spacing: 0.22em;
-  text-transform: uppercase;
-  color: var(--color-muted);
-}
-.eyebrow__index {
-  color: var(--color-accent);
-  font-variant-numeric: tabular-nums;
-}
-.eyebrow__rule {
-  flex: 1;
-  height: 1px;
-  background: var(--color-border);
-  transform-origin: left center;
-}
-
 /* ---------------------------------------------------------------- *
  * Interaction primitives (CSS-driven hover — no JS, no layout thrash)
  * ---------------------------------------------------------------- */
@@ -231,74 +209,6 @@ p {
   .work-row--link:hover .work-row__arrow {
     transform: translateX(8px);
   }
-}
-
-/* ---------------------------------------------------------------- *
- * Feature image (Alta Badia interlude)
- * ---------------------------------------------------------------- */
-
-.feature {
-  position: relative;
-  width: 100%;
-  height: clamp(60vh, 65vh, 760px);
-  overflow: hidden;
-  border-top: 1px solid var(--color-border);
-  border-bottom: 1px solid var(--color-border);
-}
-.feature__media {
-  position: absolute;
-  inset: -12% 0;
-  width: 100%;
-  height: 124%;
-  object-fit: cover;
-  /* Tonal treatment: desaturate + cool the placeholder so the accent pops. */
-  filter: grayscale(0.35) contrast(1.05) brightness(0.85);
-  will-change: transform;
-}
-/* Accent duotone wash + edge scrims for caption legibility */
-.feature__wash {
-  position: absolute;
-  inset: 0;
-  background:
-    radial-gradient(
-      120% 80% at 70% 15%,
-      color-mix(in oklab, var(--color-accent) 14%, transparent),
-      transparent 55%
-    ),
-    linear-gradient(
-      to bottom,
-      color-mix(in oklab, var(--color-background) 55%, transparent) 0%,
-      transparent 30%,
-      transparent 55%,
-      color-mix(in oklab, var(--color-background) 92%, transparent) 100%
-    );
-  pointer-events: none;
-}
-.feature__caption {
-  position: absolute;
-  left: var(--gutter);
-  right: var(--gutter);
-  bottom: clamp(1.75rem, 4vw, 3.5rem);
-  display: flex;
-  flex-wrap: wrap;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 1rem 2rem;
-}
-.feature__quote {
-  font-family: var(--font-display);
-  font-size: clamp(1.75rem, 5vw, 4rem);
-  line-height: 0.95;
-  letter-spacing: 0.01em;
-  max-width: 18ch;
-}
-.feature__coords {
-  font-size: 0.6875rem;
-  letter-spacing: 0.22em;
-  text-transform: uppercase;
-  color: var(--color-text);
-  opacity: 0.8;
-  font-variant-numeric: tabular-nums;
 }
 
 /* ---------------------------------------------------------------- *

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,6 @@
 import Nav from '@/components/Nav';
 import Hero from '@/components/Hero';
 import About from '@/components/About';
-import Feature from '@/components/Feature';
 import Work from '@/components/Work';
 import Contact from '@/components/Contact';
 import Footer from '@/components/Footer';
@@ -13,7 +12,6 @@ export default function Home() {
       <main>
         <Hero />
         <About />
-        <Feature />
         <Work />
         <Contact />
       </main>

--- a/components/About.tsx
+++ b/components/About.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import SectionHeader from '@/components/SectionHeader';
 import { skills } from '@/lib/data';
 
 const ease = [0.16, 1, 0.3, 1] as const;
@@ -24,8 +23,6 @@ export default function About() {
   return (
     <section id="about" className="section">
       <div className="shell">
-        <SectionHeader index="01" label="About" />
-
         <div
           style={{
             display: 'grid',

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -2,7 +2,6 @@
 
 import { useRef } from 'react';
 import { motion, useMotionValue, useSpring } from 'framer-motion';
-import SectionHeader from '@/components/SectionHeader';
 
 const EMAIL = 'emanuele.colabello@gmail.com';
 const LINKEDIN = 'https://www.linkedin.com/in/emanuele-colabello-b449a291';
@@ -51,8 +50,6 @@ export default function Contact() {
         className="shell"
         style={{ display: 'flex', flexDirection: 'column', gap: '2.5rem' }}
       >
-        <SectionHeader index="03" label="Contact" />
-
         <motion.h2
           {...reveal(0)}
           transition={{ duration: 0.9, ease }}

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -4,11 +4,11 @@ import { motion } from 'framer-motion';
 
 const container = {
   hidden: {},
-  visible: { transition: { staggerChildren: 0.1, delayChildren: 0.1 } },
+  visible: { transition: { staggerChildren: 0.12 } },
 };
 
 const rise = {
-  hidden: { y: 60, opacity: 0 },
+  hidden: { y: 80, opacity: 0 },
   visible: {
     y: 0,
     opacity: 1,
@@ -21,20 +21,6 @@ const fade = {
   visible: { opacity: 1, transition: { duration: 0.8 } },
 };
 
-const meta: { label: string; value: string }[] = [
-  { label: 'Role', value: 'Front-end Developer' },
-  { label: 'Based in', value: 'Italy' },
-  { label: 'Focus', value: 'React · TypeScript · Motion' },
-];
-
-/**
- * Full-viewport opening section.
- *
- * Establishes hierarchy top-to-bottom: an availability badge, the oversized
- * name, a one-line tagline, and an editorial meta row (role / location /
- * focus). Words rise on load with a staggered spring; everything is sized
- * with fluid `clamp()` so the name never overflows on small screens.
- */
 export default function Hero() {
   return (
     <motion.section
@@ -45,135 +31,66 @@ export default function Hero() {
         minHeight: '100svh',
         display: 'flex',
         flexDirection: 'column',
-        justifyContent: 'space-between',
-        gap: '3rem',
+        justifyContent: 'flex-end',
         padding:
-          'calc(var(--gutter) + 4.5rem) var(--gutter) clamp(2rem, 5vw, 4rem)',
+          'calc(var(--gutter) + 4.5rem) var(--gutter) clamp(2.5rem, 5vw, 4.5rem)',
         position: 'relative',
       }}
     >
-      {/* Availability badge */}
-      <motion.div
-        variants={fade}
+      {/* Name */}
+      <h1
         style={{
-          display: 'inline-flex',
-          alignItems: 'center',
-          gap: '0.6rem',
-          alignSelf: 'flex-start',
-          fontSize: '0.6875rem',
-          letterSpacing: '0.2em',
-          textTransform: 'uppercase',
-          color: 'var(--color-muted)',
+          fontFamily: 'var(--font-display)',
+          fontSize: 'clamp(3.5rem, 13vw, 13rem)',
+          lineHeight: 0.88,
+          letterSpacing: '-0.01em',
         }}
       >
-        <motion.span
-          aria-hidden
-          animate={{ opacity: [1, 0.25, 1] }}
-          transition={{ duration: 2, repeat: Infinity, ease: 'easeInOut' }}
-          style={{
-            width: 8,
-            height: 8,
-            borderRadius: '50%',
-            background: 'var(--color-accent)',
-            boxShadow: '0 0 12px var(--color-accent)',
-          }}
-        />
-        Available for work — 2025
-      </motion.div>
+        {['EMANUELE', 'COLABELLO'].map((word, i) => (
+          <span key={word} style={{ display: 'block', overflow: 'hidden' }}>
+            <motion.span
+              variants={rise}
+              style={{
+                display: 'block',
+                color: i === 1 ? 'var(--color-muted)' : 'var(--color-text)',
+              }}
+            >
+              {word}
+            </motion.span>
+          </span>
+        ))}
+      </h1>
 
-      {/* Name + tagline */}
-      <div>
-        <h1
-          style={{
-            fontFamily: 'var(--font-display)',
-            fontSize: 'clamp(3.5rem, 13vw, 12.5rem)',
-            lineHeight: 0.86,
-            letterSpacing: '-0.01em',
-          }}
-        >
-          {['EMANUELE', 'COLABELLO'].map((word, i) => (
-            <span key={word} style={{ display: 'block', overflow: 'hidden' }}>
-              <motion.span
-                variants={rise}
-                style={{
-                  display: 'block',
-                  color: i === 1 ? 'var(--color-muted)' : 'var(--color-text)',
-                }}
-              >
-                {word}
-              </motion.span>
-            </span>
-          ))}
-        </h1>
-
-        <div style={{ overflow: 'hidden', marginTop: '1.75rem' }}>
-          <motion.p
-            variants={rise}
-            style={{
-              fontSize: 'clamp(1rem, 1.6vw, 1.375rem)',
-              lineHeight: 1.5,
-              color: 'var(--color-text)',
-              maxWidth: '34ch',
-            }}
-          >
-            Front-end developer{' '}
-            <span style={{ color: 'var(--color-accent)' }}>crafting</span>{' '}
-            expressive, high-performance interfaces with React.
-          </motion.p>
-        </div>
-      </div>
-
-      {/* Meta row + scroll cue */}
+      {/* Tagline + scroll cue */}
       <motion.div
         variants={fade}
         style={{
           display: 'flex',
           flexWrap: 'wrap',
-          alignItems: 'flex-end',
+          alignItems: 'baseline',
           justifyContent: 'space-between',
-          gap: '2rem',
-          borderTop: '1px solid var(--color-border)',
+          gap: '1.5rem 3rem',
+          marginTop: '2rem',
           paddingTop: '1.5rem',
+          borderTop: '1px solid var(--color-border)',
         }}
       >
-        <dl
+        <p
           style={{
-            display: 'flex',
-            flexWrap: 'wrap',
-            gap: '1.5rem clamp(2rem, 5vw, 4rem)',
-            margin: 0,
+            fontSize: 'clamp(0.9375rem, 1.5vw, 1.125rem)',
+            lineHeight: 1.6,
+            color: 'var(--color-muted)',
+            maxWidth: '38ch',
           }}
         >
-          {meta.map(({ label, value }) => (
-            <div key={label}>
-              <dt
-                style={{
-                  fontSize: '0.625rem',
-                  letterSpacing: '0.18em',
-                  textTransform: 'uppercase',
-                  color: 'var(--color-muted)',
-                  marginBottom: '0.35rem',
-                }}
-              >
-                {label}
-              </dt>
-              <dd
-                style={{
-                  margin: 0,
-                  fontSize: '0.875rem',
-                  color: 'var(--color-text)',
-                }}
-              >
-                {value}
-              </dd>
-            </div>
-          ))}
-        </dl>
+          Front-end developer —{' '}
+          <span style={{ color: 'var(--color-accent)' }}>crafting</span>{' '}
+          expressive interfaces with React.
+        </p>
 
-        <motion.a
+        <a
           href="#about"
           aria-label="Scroll to content"
-          data-cursor-grow
           className="link-muted"
           style={{
             display: 'inline-flex',
@@ -182,6 +99,7 @@ export default function Hero() {
             fontSize: '0.6875rem',
             letterSpacing: '0.18em',
             textTransform: 'uppercase',
+            flexShrink: 0,
           }}
         >
           Scroll
@@ -192,7 +110,7 @@ export default function Hero() {
           >
             ↓
           </motion.span>
-        </motion.a>
+        </a>
       </motion.div>
     </motion.section>
   );

--- a/components/Work.tsx
+++ b/components/Work.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import SectionHeader from '@/components/SectionHeader';
 import { projects, type Project } from '@/lib/data';
 
 const rowVariants = {
@@ -71,8 +70,6 @@ export default function Work() {
   return (
     <section id="work" className="section">
       <div className="shell">
-        <SectionHeader index="02" label="Selected Work" />
-
         <motion.h2
           initial={{ opacity: 0, y: 24 }}
           whileInView={{ opacity: 1, y: 0 }}


### PR DESCRIPTION
## Summary
This PR streamlines the portfolio homepage by simplifying the Hero component and removing editorial section headers and feature image components. The changes focus the design on core content while reducing visual complexity.

## Key Changes

- **Hero Section Refactor**
  - Removed availability badge and meta information row (role, location, focus)
  - Simplified layout from `space-between` to `flex-end` justification
  - Adjusted animation timings: increased `staggerChildren` from 0.1 to 0.12, increased rise animation from `y: 60` to `y: 80`
  - Consolidated tagline directly below name with improved spacing
  - Removed `data-cursor-grow` attribute and motion wrapper from scroll link
  - Updated font sizing: name increased to `13rem` max, adjusted padding and margins

- **Removed Components**
  - Deleted `SectionHeader` component usage from About, Work, and Contact sections
  - Removed `Feature` component (Alta Badia interlude image section) from page layout
  - Removed associated CSS for `.eyebrow`, `.feature`, and related styling

- **CSS Cleanup**
  - Removed `.eyebrow` and `.eyebrow__*` utility classes
  - Removed `.feature`, `.feature__*` classes and complex gradient/filter styling
  - Cleaned up unused editorial styling patterns

## Implementation Details

The Hero section now presents a cleaner, more direct visual hierarchy with the name as the primary focal point, followed by a concise tagline and scroll indicator. The removal of meta information and availability status simplifies the initial impression while maintaining the animated entrance effect with adjusted timing parameters.

https://claude.ai/code/session_01UY5uQKgVsStzKgUQ6e2BiK